### PR TITLE
Invoice: production-safe links + base URL fallback + admin UI fixes

### DIFF
--- a/pages/admin/orders/[id].js
+++ b/pages/admin/orders/[id].js
@@ -70,6 +70,14 @@ export default function AdminOrderDetails() {
   const { id } = router.query;
   const { user } = useAuth();
 
+    // Production-safe base URL for external links (use NEXT_PUBLIC_BASE_URL on Vercel)
+  const baseURL = useMemo(
+  () =>
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    (typeof window !== "undefined" ? window.location.origin : "http://localhost:3000"),
+  []
+);
+
   const [activeTab, setActiveTab] = useState("order"); // 'order' | 'replacements' | 'history'
   const [order, setOrder] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -265,9 +273,9 @@ export default function AdminOrderDetails() {
             <div className="flex items-center gap-2">
               <InvoiceButton orderId={order.id} />{/* server-generated invoice */}
               <a
-                href={`/api/invoice/${order.id}`}
+                href={`${baseURL}/api/invoice/${order.id}`}
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="px-4 py-2 rounded-md border text-sm hover:bg-gray-50"
                 title="Open invoice in new tab"
               >
@@ -558,9 +566,9 @@ export default function AdminOrderDetails() {
                     View Public Order Page
                   </Link>
                   <a
-                    href={`/api/invoice/${order.id}`}
+                    href={`${baseURL}/api/invoice/${order.id}`}
                     target="_blank"
-                    rel="noreferrer"
+                    rel="noopener noreferrer"
                     className="px-3 py-1.5 rounded-md border hover:bg-gray-50"
                   >
                     Open Invoice

--- a/pages/admin/replacements/index.js
+++ b/pages/admin/replacements/index.js
@@ -101,6 +101,15 @@ export default function AdminReplacementsPage() {
   const [qText, setQText] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
 
+  // production-safe base URL for absolute invoice links (client-side)
+  const baseURL = useMemo(
+    () =>
+      process.env.NEXT_PUBLIC_BASE_URL ||
+      (typeof window !== "undefined" ? window.location.origin : "http://localhost:3000"),
+    []
+  );
+
+  // Auth + admin check
   if (!user) {
     return (
       <div className="min-h-[60vh] grid place-items-center">
@@ -321,9 +330,9 @@ export default function AdminReplacementsPage() {
                         View Order
                       </Link>
                       <a
-                        href={`/api/invoice/${r.orderId}`}
+                        href={`${baseURL}/api/invoice/${r.orderId}`}
                         target="_blank"
-                        rel="noreferrer"
+                        rel="noopener noreferrer"
                         className="px-3 py-1.5 rounded-md border text-sm hover:bg-gray-50"
                       >
                         Invoice
@@ -398,9 +407,9 @@ export default function AdminReplacementsPage() {
                               View Order
                             </Link>
                             <a
-                              href={`/api/invoice/${r.orderId}`}
+                              href={`${baseURL}/api/invoice/${r.orderId}`}
                               target="_blank"
-                              rel="noreferrer"
+                              rel="noopener noreferrer"
                               className="text-xs text-blue-600 hover:underline"
                             >
                               Invoice

--- a/pages/api/invoice/[orderId].ts
+++ b/pages/api/invoice/[orderId].ts
@@ -3,6 +3,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { adminDb } from "../../../lib/firebaseAdmin";
 import { generateInvoiceBuffer } from "../../../lib/invoice";
 
+function safeFilename(s: string) {
+  return s.replace(/[^a-zA-Z0-9-_\.]/g, "-");
+}
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { orderId } = req.query;
 
@@ -22,19 +26,27 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(404).json({ error: "Order not found" });
     }
 
-    const order = snap.data();
-    // @ts-ignore - order typing from Firestore
+    // --- TS fix: assert order exists and give it a safe type so generateInvoiceBuffer accepts it ---
+    const order = snap.data() as Record<string, any>; // <-- important: this removes the TS "possibly undefined" error
+
+    // generateInvoiceBuffer should return a Buffer, Uint8Array or ArrayBuffer
     const buffer = await generateInvoiceBuffer(order, orderIdStr);
 
+    const buf = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer);
+
+    // Security + caching headers
     res.setHeader("Content-Type", "application/pdf");
     res.setHeader(
       "Content-Disposition",
-      `inline; filename=invoice-${orderIdStr}.pdf`
+      `inline; filename="${safeFilename(`invoice-${orderIdStr}.pdf`)}"`
     );
+    res.setHeader("Content-Length", String(buf.length));
+    // private so browsers / proxies don't cache user-specific invoices
+    res.setHeader("Cache-Control", "private, max-age=0, must-revalidate");
 
-    res.status(200).send(Buffer.from(buffer));
+    return res.status(200).send(buf);
   } catch (err: any) {
-    console.error("🔥 Invoice generation failed:", err?.message || err);
-    res.status(500).json({ error: "Failed to generate invoice" });
+    console.error("🔥 Invoice generation failed:", err?.message || err, err?.stack || "");
+    return res.status(500).json({ error: "Failed to generate invoice" });
   }
 }

--- a/pages/order/[id].js
+++ b/pages/order/[id].js
@@ -58,6 +58,14 @@ export default function OrderDetailPage() {
   const [loading, setLoading] = useState(true);
   const [timelineOpen, setTimelineOpen] = useState(false);
 
+  // production-safe base URL for invoice links (client-side)
+  const baseURL = useMemo(
+    () =>
+      process.env.NEXT_PUBLIC_BASE_URL ||
+      (typeof window !== "undefined" ? window.location.origin : "http://localhost:3000"),
+    []
+  );
+
   // ⚡ Live Firestore Listener
   useEffect(() => {
     if (!id) return;
@@ -100,7 +108,16 @@ export default function OrderDetailPage() {
 
   const handleDownloadInvoice = () => {
     if (!order?.id) return;
-    window.open(`/api/invoice/${order.id}`, "_blank");
+    try {
+      const url = `${baseURL}/api/invoice/${order.id}`;
+      const newWin = window.open(url, "_blank");
+      if (newWin) {
+        try { newWin.opener = null; } catch {}
+      }
+    } catch (err) {
+      console.error("Failed to open invoice:", err);
+      toast.error("Unable to open invoice. Please try again.");
+    }
   };
 
   // 🧾 Loading State (Shimmer UI)


### PR DESCRIPTION
✔ Changes included:

Use NEXT_PUBLIC_BASE_URL (fallback to runtime origin) for all invoice links (InvoiceButton, admin replacements, admin order pages, order pages, order-success).

Updated InvoiceButton.jsx to use absolute production URLs.

Cleaned invoice link logic in:

/order-success
/order/[id]
/profile
/admin/orders/[id]
/admin/replacements


Improved API /api/invoice/[orderId].ts:

Set Content-Length and Cache-Control: private, max-age=0, must-revalidate.
Sanitized filename in Content-Disposition.
TypeScript fix for snap.data() typing.