### PR TITLE
fix(payments): allow CORS preflight OPTIONS for Razorpay APIs

### DIFF
--- a/pages/api/razorpay.js
+++ b/pages/api/razorpay.js
@@ -3,9 +3,22 @@ import Razorpay from "razorpay";
 import { admin, adminDb } from "../../lib/firebaseAdmin"; // adjust if your exports differ
 import { v4 as uuidv4 } from "uuid";
 
+const ALLOWED_ORIGIN = process.env.NEXT_PUBLIC_BASE_URL || "*";
+
 export default async function handler(req, res) {
+  // CORS preflight support
+  if (req.method === "OPTIONS") {
+    res.setHeader("Access-Control-Allow-Origin", ALLOWED_ORIGIN);
+    res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    return res.status(200).end();
+  }
+
+  // always set CORS header for normal responses too (same-origin safe)
+  res.setHeader("Access-Control-Allow-Origin", ALLOWED_ORIGIN);
+
   if (req.method !== "POST") {
-    res.setHeader("Allow", "POST");
+    res.setHeader("Allow", "POST, OPTIONS");
     return res.status(405).json({ error: "Method Not Allowed" });
   }
 

--- a/pages/api/verify-razorpay.js
+++ b/pages/api/verify-razorpay.js
@@ -5,9 +5,22 @@ import { admin, adminDb } from "../../lib/firebaseAdmin";
 import { generateInvoiceBuffer } from "../../lib/invoice";
 import { zoneFromPincode, etaRange } from "@/lib/logistics";
 
+const ALLOWED_ORIGIN = process.env.NEXT_PUBLIC_BASE_URL || "*";
+
 export default async function handler(req, res) {
+  // CORS preflight support
+  if (req.method === "OPTIONS") {
+    res.setHeader("Access-Control-Allow-Origin", ALLOWED_ORIGIN);
+    res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    return res.status(200).end();
+  }
+
+  // always set CORS header for normal responses too
+  res.setHeader("Access-Control-Allow-Origin", ALLOWED_ORIGIN);
+
   if (req.method !== "POST") {
-    res.setHeader("Allow", "POST");
+    res.setHeader("Allow", "POST, OPTIONS");
     return res.status(405).json({ error: "Method Not Allowed" });
   }
 


### PR DESCRIPTION
This patch allows CORS preflight (OPTIONS) on /api/razorpay and /api/verify-razorpay so the browser's preflight no longer returns 405.
- Adds OPTIONS handler and Access-Control-Allow-* headers.
- Keeps existing create/verify logic unchanged.

